### PR TITLE
0717-0718 로그인했을때 logcalStorage에 admin_type_name 또한 저장할 수 있게끔 했음. 

### DIFF
--- a/src/main/java/com/jakdang/labs/api/jungeun/dto/LoginAdminDTO.java
+++ b/src/main/java/com/jakdang/labs/api/jungeun/dto/LoginAdminDTO.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class LoginAdminDTO {
     private Integer userIndex;
     private Integer adminTypeIndex;
+    private String adminTypeName;
 }

--- a/src/main/java/com/jakdang/labs/api/jungeun/dto/LoginResponseDTO.java
+++ b/src/main/java/com/jakdang/labs/api/jungeun/dto/LoginResponseDTO.java
@@ -22,5 +22,6 @@ public class LoginResponseDTO {
     private String createdAt;
     private String user_role_index;
     private String admin_type_index;
+    private String admin_type_name;
     private String user_index;
 }

--- a/src/main/java/com/jakdang/labs/api/jungeun/service/AdminLjeSvc.java
+++ b/src/main/java/com/jakdang/labs/api/jungeun/service/AdminLjeSvc.java
@@ -17,6 +17,7 @@ public class AdminLjeSvc {
         return adminLjeRepo.findByUserIndex(userIndex)
             .map(admin -> LoginAdminDTO.builder()
                 .adminTypeIndex(admin.getAdminTypeIndex().getAdminTypeIndex()) // ManyToOne일 경우
+                .adminTypeName(admin.getAdminTypeIndex().getAdminTypeName())   // 여기!
                 .build())
             .orElse(null);
     }

--- a/src/main/java/com/jakdang/labs/security/jwt/LoginFilter.java
+++ b/src/main/java/com/jakdang/labs/security/jwt/LoginFilter.java
@@ -159,9 +159,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // 2. (**0715 정은 추가) Admin일 경우 admin_type_index까지 받기
         Integer admin_type_index = null;
+        String admin_type_name = null;
         LoginAdminDTO admin = adminLjeSvc.findByUserIndex(user_index);
         if(admin != null){
             admin_type_index = admin.getAdminTypeIndex();
+            admin_type_name = admin.getAdminTypeName();
         }
         
 
@@ -224,6 +226,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
                         .createdAt(createdAt)
                         .user_role_index(String.valueOf(user_role_index))
                         .admin_type_index(admin_type_index == null ? "관리자회원X" : String.valueOf(admin_type_index))
+                        .admin_type_name(admin_type_name)
                         .user_index(String.valueOf(user_index))
                         .build();
 


### PR DESCRIPTION
0717-0718 로그인했을때 logcalStorage에 admin_type_name 또한 저장할 수 있게끔 했음. 

Navi에 관리자 등급 한 번 보여주겠다고 Server-DB 가는거 비효율적이라고 생각함!
그리고 본사, 전산개발, 경리담당 등 -> 이런 관리자 등급이 노출되어서는 안되는 개인정보라고 생각하지 않았음.